### PR TITLE
Leverage cisagov/ansible-role-pip instead of installing pip manually

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,10 +2,9 @@
 # boto3 is installed anywhere we would be applying this Ansible role
 - name: Prepare
   hosts: all
+  roles:
+    - pip
   tasks:
-    - name: Install pip
-      package:
-        name: python-pip
     - name: Install boto3
       pip:
         name: boto3

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,5 @@
 ---
 - src: https://github.com/cisagov/ansible-role-cyhy-core
   name: cyhy_core
+- src: https://github.com/cisagov/ansible-role-pip
+  name: pip


### PR DESCRIPTION
This is in `prepare.yml`.