### PR TITLE
Install the gunicorn package instead of the python-gunicorn package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
       - python-apscheduler
       - python-eventlet
       - python-schedule
-      - python-gunicorn
+      - gunicorn
 
 - name: Install ncats-webd
   pip:


### PR DESCRIPTION
The gunicorn package installs the python-gunicorn package as a dependency and installs the `gunicorn` executable as well.