### PR TITLE
Install dependencies via pip instead of aptitude

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,29 +21,6 @@
 #
 # Install ncats-webd
 #
-
-# These dependencies are from here:
-# https://github.com/jsf9k/cal-overlay/blob/develop/net-analyzer/ncats-webd/ncats-webd-2.0.2.ebuild#L31-L47
-#
-# I'd prefer to install the python dependencies via pip, but then I
-# get errors about modules being built with a different version of
-# numpy than what is on the host.  Doing it this way seems to work
-# much better.
-- name: Install ncats-webd dependencies
-  package:
-    name:
-      - python-numpy
-      - python-dateutil
-      - python-netaddr
-      - python-pandas
-      - python-docopt
-      - python-flask
-      - python-flask-sockets
-      - python-apscheduler
-      - python-eventlet
-      - python-schedule
-      - gunicorn
-
 - name: Install ncats-webd
   pip:
     name: file:///var/local/ncats-webd


### PR DESCRIPTION
This is clearly a better option, but we need to ensure that both the reporter and dashboard instances still function with this change.  I seem to recall that the reporter had issues with this because it was finicky about how the numpy python modules were compiled.