### PR TITLE
Update the supported platforms

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,8 @@ galaxy_info:
   min_ansible_version: 2.10
   namespace: cisagov
   platforms:
+    # ncats-webd is still Python 2 and with distributions ending support for
+    # Python 2 we can only support a limited number of platforms.
     - name: Debian
       versions:
         - stretch

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,10 @@ galaxy_info:
     - name: Debian
       versions:
         - stretch
+        - buster
+    - name: Ubuntu
+      versions:
+        - bionic
   role_name: ncats_webd
 
 dependencies:

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -24,8 +24,8 @@ platforms:
   - name: debian9
     image: debian:stretch-slim
     dockerfile: Dockerfile_debian_9.j2
-  # - name: debian10
-  #   image: debian:buster-slim
+  - name: debian10
+    image: debian:buster-slim
   # - name: debian11
   #   image: debian:bullseye-slim
   # - name: debian12
@@ -36,8 +36,8 @@ platforms:
   #   image: fedora:34
   # - name: fedora35
   #   image: fedora:35
-  # - name: ubuntu18
-  #   image: ubuntu:bionic
+  - name: ubuntu18
+    image: ubuntu:bionic
   # - name: ubuntu20
   #   image: ubuntu:focal
 provisioner:

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,9 +16,8 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  # ncats-webd is Python 2 only, and the only platform we currently support
-  # for Python 2 is Debian Stretch. Until this restriction changes we need to
-  # disable testing for all other platforms.
+  # ncats-webd is still Python 2 and with distributions ending support for
+  # Python 2 we can only support a limited number of platforms.
   # - name: amazonlinux2
   #   image: amazonlinux:2
   - name: debian9

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,9 +1,12 @@
 ---
 - hosts: all
-  name: Install pip3/python3 and remove pip2/python2
+  name: Install pip3/python3 and pip2/python2
   become: yes
   become_method: sudo
   roles:
-    - pip
-    - python
-    - remove_python2
+    - role: pip
+      vars:
+        install_pip2: true
+    - role: python
+      vars:
+        install_python2: true

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,9 +1,12 @@
 ---
 - src: https://github.com/cisagov/ansible-role-cyhy-core
   name: cyhy_core
+  version: improvement/update_platforms_supported
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
+  version: improvement/control-installation-of-pip2-via-role-var
 - src: https://github.com/cisagov/ansible-role-python
   name: python
+  version: improvement/control-installation-of-python2-via-role-var
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -5,7 +5,5 @@
   name: pip
 - src: https://github.com/cisagov/ansible-role-python
   name: python
-- src: https://github.com/cisagov/ansible-role-remove-python2
-  name: remove_python2
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,12 +1,9 @@
 ---
 - src: https://github.com/cisagov/ansible-role-cyhy-core
   name: cyhy_core
-  version: improvement/update_platforms_supported
 - src: https://github.com/cisagov/ansible-role-pip
   name: pip
-  version: improvement/control-installation-of-pip2-via-role-var
 - src: https://github.com/cisagov/ansible-role-python
   name: python
-  version: improvement/control-installation-of-python2-via-role-var
 - src: https://github.com/cisagov/ansible-role-upgrade
   name: upgrade

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,16 +12,29 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
+@pytest.mark.parametrize(
+    "pkg",
+    [
+        "gunicorn",
+        "python-cffi",
+        "python-dateutil",
+        "python-docopt",
+        "python-flask",
+        "python-gevent",
+        "python-gunicorn",
+        "python-netaddr",
+        "python-schedule",
+    ],
+)
+def test_apt_packages(host, pkg):
+    """Test that the apt packages were installed."""
+    assert host.package(pkg).is_installed
+
+
 @pytest.mark.parametrize("pkg", ["ncats-webd"])
-def test_packages(host, pkg):
+def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
     assert pkg in host.pip_package.get_packages()
-
-
-@pytest.mark.parametrize("f", ["/var/local/ncats-webd"])
-def test_files(host, f):
-    """Test that the expected files and directories are present."""
-    assert host.file(f).exists
 
 
 @pytest.mark.parametrize("command", ["gunicorn"])

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -34,7 +34,7 @@ def test_apt_packages(host, pkg):
 @pytest.mark.parametrize("pkg", ["ncats-webd"])
 def test_pip_packages(host, pkg):
     """Test that the pip packages were installed."""
-    assert pkg in host.pip_package.get_packages()
+    assert pkg in host.pip.get_packages(pip_path="/usr/bin/pip2")
 
 
 @pytest.mark.parametrize("command", ["gunicorn"])

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,26 +1,7 @@
 ---
 # tasks file for ncats_webd
 
-#
-# Grab the ncats-webd code
-#
-- name: Create the /var/local/ncats-webd directory
-  ansible.builtin.file:
-    mode: 0755
-    path: /var/local/ncats-webd
-    state: directory
-
-- name: Download and untar the ncats-webd tarball
-  ansible.builtin.unarchive:
-    src: "https://api.github.com/repos/cisagov/ncats-webd/tarball/develop"
-    dest: /var/local/ncats-webd
-    remote_src: yes
-    extra_opts:
-      - "--strip-components=1"
-
-#
-# Install ncats-webd
-#
-- name: Install ncats-webd
+- name: Install the ncats-webd package
   ansible.builtin.pip:
-    name: file:///var/local/ncats-webd
+    executable: /usr/bin/pip2
+    name: https://api.github.com/repos/cisagov/ncats-webd/tarball/develop

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,21 @@
 ---
 # tasks file for ncats_webd
 
+- name: Install system versions of the Python packages that ncats-webd needs
+  ansible.builtin.package:
+    name:
+      # Note that the gunicorn package is the command and python-gunicorn
+      # is the Python 2 library.
+      - gunicorn
+      - python-cffi
+      - python-dateutil
+      - python-docopt
+      - python-flask
+      - python-gevent
+      - python-gunicorn
+      - python-netaddr
+      - python-schedule
+
 - name: Install the ncats-webd package
   ansible.builtin.pip:
     executable: /usr/bin/pip2


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the platforms supported by this Ansible role in addition to ensuring that the [ncats-webd] package is installed with `pip2`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## ⚠ Note ##

This pull request is reliant on the merge of the following:

- cisagov/ansible-role-pip#50
- cisagov/ansible-role-python#46
- cisagov/ansible-role-cyhy-core#65

## 💭 Motivation and context ##

We are in the process of updating the instances in [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis) to use Debian Buster for instances running Python 2 code. With the above mentioned PRs for Python/pip installation we can expand the supported platforms. Additionally we update the installation process so that system packages are installed where available for Python libraries and the [ncats-webd] package is installed directly with pip.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [x] Revert dependencies to default branches.

[ncats-webd]: https://github.com/cisagov/ncats-webd
