### PR TITLE
Add a version pin constraint for the `greenlet` package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,4 +19,10 @@
 - name: Install the ncats-webd package
   ansible.builtin.pip:
     executable: /usr/bin/pip2
-    name: https://api.github.com/repos/cisagov/ncats-webd/tarball/develop
+    name:
+      # This pin is only strictly necessary on Debian Stretch. It can be
+      # removed once cisagov/skeleton-ansible-role#124 is merged and trickles
+      # down. Please see cisagov/ansible-role-ncats-webd#61 for more
+      # information.
+      - greenlet < 2
+      - https://api.github.com/repos/cisagov/ncats-webd/tarball/develop


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a version pin constraint for the `greenlet` package to the `pip` install step.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

[`greenlet` 2.0.0](https://pypi.org/project/greenlet/2.0.0/) will not successfully install on Debian Stretch systems because of the old version of `gcc` available. Until support for Debian Stretch is dropped in https://github.com/cisagov/skeleton-ansible-role/pull/124 we need to constrain the version of `greenlet` installed and there's no harm in constraining it for all platforms.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Currently only the `test (default)` test is passing because we need the upstream changes to our pre-commit configuration to trickle down.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
